### PR TITLE
Improve OSX support

### DIFF
--- a/autobundle.sh
+++ b/autobundle.sh
@@ -47,7 +47,7 @@ for app in `apps_to_update`; do
       echo "Bundle update - `todays_date`" > pr.txt
       echo "" >> pr.txt
       echo "Updated the following gems:" >> pr.txt
-      cat bundle_update.log | grep -P '\(was' | sed -nE 's/\w+\W*(.*)/ - \1/p' >> pr.txt
+      cat bundle_update.log | grep -E '\(was' | sed -nE 's/Using(.*)/ - \1/p' >> pr.txt
       hub pull-request -F pr.txt
       rm pr.txt bundle_update.log
     else

--- a/autobundle.sh
+++ b/autobundle.sh
@@ -3,7 +3,7 @@
 shell_session_update() { :; }
 
 function apps_to_update {
-  find . -maxdepth 2 -print | grep Gemfile.lock | sed -nr 's/\.\/(.*)\/.*/\1/p'
+  find . -maxdepth 2 -print | grep Gemfile.lock | sed -nE 's/\.\/(.*)\/.*/\1/p'
 }
 
 function todays_date {
@@ -45,7 +45,7 @@ for app in `apps_to_update`; do
       echo "Bundle update - `todays_date`" > pr.txt
       echo "" >> pr.txt
       echo "Updated the following gems:" >> pr.txt
-      cat bundle_update.log | grep -P '\(was' | sed -nr 's/\w+\W*(.*)/ - \1/p' >> pr.txt
+      cat bundle_update.log | grep -P '\(was' | sed -nE 's/\w+\W*(.*)/ - \1/p' >> pr.txt
       hub pull-request -F pr.txt
       rm pr.txt bundle_update.log
     else

--- a/autobundle.sh
+++ b/autobundle.sh
@@ -25,6 +25,8 @@ function setup_ruby_environment {
   bundle install
 }
 
+hub --help >/dev/null 2>&1 || { echo >&2 "I require hub but it is not on the path.  Aborting."; exit 1; }
+
 for app in `apps_to_update`; do
   echo "Checking $app"
   cd $app


### PR DESCRIPTION
## The problem

The script appears to be gnu-compatible, but many engineers don't have the gnu toolsets installed.

## The solution

Use POSIX-compliant flags for sed and grep.

## Bonus feature

Emit an error message if `hub` isn't found on the path.
