### PR TITLE
Use login shell & clarify a message

### DIFF
--- a/autobundle.sh
+++ b/autobundle.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash --login
 
 shell_session_update() { :; }
 
@@ -54,7 +54,7 @@ for app in `apps_to_update`; do
       echo "No updates today for $app"
     fi
   else
-    echo "Bundle update already done for the day for $app"
+    echo "Bundle update already done for the day for $app (origin branch `branch_name` exists)"
   fi
   git checkout master
   cd ..


### PR DESCRIPTION
## The problem

In my environment, ruby versions were not being set correctly and I was seeing a `RVM is not a function, selecting rubies with 'rvm use ...' will not work.` message.

## The solution

Make autobundle use a login shell per http://stackoverflow.com/questions/9336596/rvm-installation-not-working-rvm-is-not-a-function .

## The bonus

I clarified to the user how we can tell a particular date was "already done".